### PR TITLE
Added ncurses include directory using pkg-config to Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ UNAME_S := $(shell uname -s 2>/dev/null || echo not)
 
 SOURCES = $(wildcard *.c)
 OBJECTS = $(SOURCES:.c=.o)
-CFLAGS  = -O3 -Wall -I../include
+CFLAGS  = -O3 -Wall -I../include $(shell pkg-config --cflags ncursesw)
 
 ifeq ($(DEBUG),1)
 	CFLAGS := -O0 -Wall -g -I../include


### PR DESCRIPTION
This change is needed so as to get ncurses.h found on Linux Mint (probably on all other Ubuntu like environments too).
