### PR TITLE
Fix minor valgrind read error

### DIFF
--- a/src/cstring.c
+++ b/src/cstring.c
@@ -76,7 +76,7 @@ void cstring_strip(cstring_t *self, int pos, int len) {
         }
         return;
     }
-    memmove(&self->text[pos], &self->text[pos+len], self->size - pos);
+    memmove(&self->text[pos], &self->text[pos+len], self->size - pos - len+1);
     self->size -= len;
 }
 


### PR DESCRIPTION
This fixes the invalid read errors from valgrind when running the sample.md through. It seems that the cause was running memmove with a too big of a size.

`cstring_strip` looks like it's used to strip away the start and end tags and the size for memmove doesn't account for the tag length. The +1 is there for the null char.

This doesn't fix `inline_display` though.
### Before

```
$ DEBUG=1 make && valgrind ./mdp sample.md 2>out // only opened first 2 slides

==4333== Memcheck, a memory error detector
==4333== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==4333== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
==4333== Command: ./mdp sample.md
==4333== 
==4333== Invalid read of size 1
==4333==    at 0x4C2EA1E: memcpy@GLIBC_2.2.5 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401870: cstring_strip (cstring.c:79)
==4333==    by 0x403F07: markdown_analyse (parser.c:412)
==4333==    by 0x4033EE: markdown_load (parser.c:61)
==4333==    by 0x404A19: main (main.c:106)
==4333==  Address 0x543ec5a is 0 bytes after a block of size 10 alloc'd
==4333==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401635: cstring_expand (cstring.c:48)
==4333==    by 0x403661: markdown_load (parser.c:150)
==4333==    by 0x404A19: main (main.c:106)
==4333== 
==4333== Invalid read of size 1
==4333==    at 0x4C2EA10: memcpy@GLIBC_2.2.5 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401870: cstring_strip (cstring.c:79)
==4333==    by 0x403F07: markdown_analyse (parser.c:412)
==4333==    by 0x4033EE: markdown_load (parser.c:61)
==4333==    by 0x404A19: main (main.c:106)
==4333==  Address 0x543fa58 is 0 bytes after a block of size 40 alloc'd
==4333==    at 0x4C2C29E: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401635: cstring_expand (cstring.c:48)
==4333==    by 0x403661: markdown_load (parser.c:150)
==4333==    by 0x404A19: main (main.c:106)
==4333== 
==4333== Invalid read of size 1
==4333==    at 0x402C64: inline_display (viewer.c:615)
==4333==    by 0x402A19: add_line (viewer.c:547)
==4333==    by 0x402050: ncurses_display (viewer.c:277)
==4333==    by 0x404ACC: main (main.c:124)
==4333==  Address 0x544109f is 1 bytes before a block of size 10 alloc'd
==4333==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401635: cstring_expand (cstring.c:48)
==4333==    by 0x40355C: markdown_load (parser.c:127)
==4333==    by 0x404A19: main (main.c:106)
==4333== 
==4333== Invalid read of size 1
==4333==    at 0x402C73: inline_display (viewer.c:616)
==4333==    by 0x402A19: add_line (viewer.c:547)
==4333==    by 0x402050: ncurses_display (viewer.c:277)
==4333==    by 0x404ACC: main (main.c:124)
==4333==  Address 0x544109f is 1 bytes before a block of size 10 alloc'd
==4333==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401635: cstring_expand (cstring.c:48)
==4333==    by 0x40355C: markdown_load (parser.c:127)
==4333==    by 0x404A19: main (main.c:106)
==4333== 
==4333== Invalid read of size 1
==4333==    at 0x402C82: inline_display (viewer.c:616)
==4333==    by 0x402A19: add_line (viewer.c:547)
==4333==    by 0x402050: ncurses_display (viewer.c:277)
==4333==    by 0x404ACC: main (main.c:124)
==4333==  Address 0x544109f is 1 bytes before a block of size 10 alloc'd
==4333==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4333==    by 0x401635: cstring_expand (cstring.c:48)
==4333==    by 0x40355C: markdown_load (parser.c:127)
==4333==    by 0x404A19: main (main.c:106)
==4333== 
==4333== 
==4333== HEAP SUMMARY:
==4333==     in use at exit: 1,026,613 bytes in 1,082 blocks
==4333==   total heap usage: 1,647 allocs, 565 frees, 1,052,635 bytes allocated
==4333== 
==4333== LEAK SUMMARY:
==4333==    definitely lost: 88 bytes in 2 blocks
==4333==    indirectly lost: 26,692 bytes in 568 blocks
==4333==      possibly lost: 0 bytes in 0 blocks
==4333==    still reachable: 999,833 bytes in 512 blocks
==4333==         suppressed: 0 bytes in 0 blocks
==4333== Rerun with --leak-check=full to see details of leaked memory
==4333== 
==4333== For counts of detected and suppressed errors, rerun with: -v
==4333== ERROR SUMMARY: 36 errors from 5 contexts (suppressed: 0 from 0)
```
### After

```
$ DEBUG=1 make && valgrind ./mdp sample.md 2>out // only opened first 2 slides

==4435== Memcheck, a memory error detector
==4435== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==4435== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
==4435== Command: ./mdp sample.md
==4435== 
==4435== Invalid read of size 1
==4435==    at 0x402C73: inline_display (viewer.c:615)
==4435==    by 0x402A28: add_line (viewer.c:547)
==4435==    by 0x40205F: ncurses_display (viewer.c:277)
==4435==    by 0x404ADB: main (main.c:124)
==4435==  Address 0x544109f is 1 bytes before a block of size 10 alloc'd
==4435==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4435==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4435==    by 0x401635: cstring_expand (cstring.c:48)
==4435==    by 0x40356B: markdown_load (parser.c:127)
==4435==    by 0x404A28: main (main.c:106)
==4435== 
==4435== Invalid read of size 1
==4435==    at 0x402C82: inline_display (viewer.c:616)
==4435==    by 0x402A28: add_line (viewer.c:547)
==4435==    by 0x40205F: ncurses_display (viewer.c:277)
==4435==    by 0x404ADB: main (main.c:124)
==4435==  Address 0x544109f is 1 bytes before a block of size 10 alloc'd
==4435==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4435==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4435==    by 0x401635: cstring_expand (cstring.c:48)
==4435==    by 0x40356B: markdown_load (parser.c:127)
==4435==    by 0x404A28: main (main.c:106)
==4435== 
==4435== Invalid read of size 1
==4435==    at 0x402C91: inline_display (viewer.c:616)
==4435==    by 0x402A28: add_line (viewer.c:547)
==4435==    by 0x40205F: ncurses_display (viewer.c:277)
==4435==    by 0x404ADB: main (main.c:124)
==4435==  Address 0x544109f is 1 bytes before a block of size 10 alloc'd
==4435==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4435==    by 0x4C2C33F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4435==    by 0x401635: cstring_expand (cstring.c:48)
==4435==    by 0x40356B: markdown_load (parser.c:127)
==4435==    by 0x404A28: main (main.c:106)
==4435== 
==4435== 
==4435== HEAP SUMMARY:
==4435==     in use at exit: 1,026,613 bytes in 1,082 blocks
==4435==   total heap usage: 1,647 allocs, 565 frees, 1,052,635 bytes allocated
==4435== 
==4435== LEAK SUMMARY:
==4435==    definitely lost: 88 bytes in 2 blocks
==4435==    indirectly lost: 26,692 bytes in 568 blocks
==4435==      possibly lost: 0 bytes in 0 blocks
==4435==    still reachable: 999,833 bytes in 512 blocks
==4435==         suppressed: 0 bytes in 0 blocks
==4435== Rerun with --leak-check=full to see details of leaked memory
==4435== 
==4435== For counts of detected and suppressed errors, rerun with: -v
==4435== ERROR SUMMARY: 12 errors from 3 contexts (suppressed: 0 from 0)
```
