### PR TITLE
Fixed memory leaks

### DIFF
--- a/include/markdown.h
+++ b/include/markdown.h
@@ -82,5 +82,6 @@ line_t *next_line(line_t *prev);
 slide_t *new_slide();
 slide_t *next_slide(slide_t *prev);
 deck_t *new_deck();
+void free_deck(deck_t *);
 
 #endif // !defined( MARKDOWN_H )

--- a/src/main.c
+++ b/src/main.c
@@ -123,5 +123,7 @@ int main(int argc, char *argv[]) {
 
     ncurses_display(deck, notrans, nofade, invert);
 
+    free_deck(deck);
+
     return EXIT_SUCCESS;
 }

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -61,3 +61,28 @@ deck_t *new_deck() {
     x->slides = x->headers = 0;
     return x;
 }
+
+void free_line(line_t *l) {
+    line_t *n;
+    while (l) {
+        n = l->next;
+        cstring_delete(l->text);
+        free(l);
+        l = n;
+    }
+}
+
+void free_deck(deck_t *deck) {
+    slide_t *s, *t;
+    if (deck == NULL)
+        return;
+    s = deck->slide;
+    while (s) {
+        free_line(s->line);
+        t = s->next;
+        free(s);
+        s = t;
+    }
+    free_line(deck->header);
+    free(deck);
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -161,6 +161,7 @@ deck_t *markdown_load(FILE *input) {
             }
         }
     }
+    cstring_delete(text);
 
     slide->lines = lc;
     deck->slides = sc;


### PR DESCRIPTION
Free up all memory on exit so valgrind reports zero leaks. Also fixes leaking one `cstring_t` for every line of text that does not end up in a `line_t`.while parsing (e.g. empty slides)
