### PR TITLE
Navigate to any slide number, resolves #73

### DIFF
--- a/include/viewer.h
+++ b/include/viewer.h
@@ -50,6 +50,7 @@
 #define CP_BLACK  5 // CP_WHITE with foreground and background swapped
 
 #define FADE_DELAY 15000 // micro seconds
+#define GOTO_SLIDE_DELAY 5    // tenths of seconds
 
 int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload);
 void add_line(WINDOW *window, int y, int x, line_t *line, int max_cols, int colors);
@@ -57,5 +58,6 @@ void inline_display(WINDOW *window, const char *c, const int colors);
 void fade_out(WINDOW *window, int trans, int colors, int invert);
 void fade_in(WINDOW *window, int trans, int colors, int invert);
 int int_length (int val);
+int get_slide_number(char init);
 
 #endif // !defined( VIEWER_H )

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -361,16 +361,17 @@ int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reloa
                 break;
 
             // show slide n
-            case '9': i++;
-            case '8': i++;
-            case '7': i++;
-            case '6': i++;
-            case '5': i++;
-            case '4': i++;
-            case '3': i++;
-            case '2': i++;
-            case '1': i++;
-                if(i <= deck->slides) {
+            case '9':
+            case '8':
+            case '7':
+            case '6':
+            case '5':
+            case '4':
+            case '3':
+            case '2':
+            case '1':
+                i = get_slide_number(c);
+                if(i > 0 && i <= deck->slides) {
                     while(sc != i) {
                         // search forward
                         if(sc < i) {
@@ -838,4 +839,21 @@ int int_length (int val) {
         val /= 10;
     }
     return l;
+}
+
+int get_slide_number(char init) {
+    int retval = init - '0';
+    char c;
+    // block for tenths of a second when using getch, ERR if no input
+    halfdelay(GOTO_SLIDE_DELAY);
+    while((c = getch()) != ERR) {
+        if (c < '0' || c > '9') {
+            retval = -1;
+            break;
+        }
+        retval = (retval * 10) + (c - '0');
+    }
+    nocbreak();     // cancel half delay mode
+    cbreak();       // go back to cbreak
+    return retval;
 }


### PR DESCRIPTION
Some changes to resolve #73 and allow navigation to any page. A digit is typed in within the time limit (GOTO_SLIDE_DELAY / 10 seconds), the time limit essentially resets after each digit, and then the slide changes when no more digits are entered after the time limit elapses. I have only tried this on cygwin.