### PR TITLE
Add vi-ish navigation to first and last slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Review sample.md for more details.
 - h, j, k, l, Arrow keys,
     Space, Enter, Backspace,
     Page Up, Page Down - next/previous slide
-- Home - go to first slide
-- End - go to last slide
+- Home, g - go to first slide
+- End, G - go to last slide
 - 1-9 - go to slide n
 - r - reload input file
 - q - exit

--- a/sample.md
+++ b/sample.md
@@ -18,8 +18,8 @@ previous slide  *Backspace*, *Page Up*, *h*, *k*,
 quit            *q*
 reload          *r*
 slide N         *1..9*
-first slide     *Home*
-last slide      *End*
+first slide     *Home*, *g*
+last slide      *End*, *G*
 
 -------------------------------------------------
 

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -394,12 +394,14 @@ int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reloa
                 break;
 
             // show first slide
+            case 'g':
             case KEY_HOME:
                 slide = deck->slide;
                 sc = 1;
                 break;
 
             // show last slide
+            case 'G':
             case KEY_END:
                 for(i = sc; i <= deck->slides; i++) {
                     if(slide->next) {


### PR DESCRIPTION
Navigate to first and last slide with 'g' and 'G', respectively. This resembles
the behavior of vi, that uses 'gg' and 'G' for the first and last lines in a
file. These keybinds are useful for keyboards without dedicated home/end keys.