### PR TITLE
Fixed crash caused by invalid pandoc urls

### DIFF
--- a/src/viewer.c
+++ b/src/viewer.c
@@ -713,7 +713,7 @@ void inline_display(WINDOW *window, const wchar_t *c, const int colors) {
 
                         if (*i == L'!') i++;
 
-                        if (wcschr(i, L']')[1] == L'(') {
+                        if (wcschr(i, L']')[1] == L'(' && wcschr(i, L')')) {
                             i++;
 
                             // turn higlighting and underlining on


### PR DESCRIPTION
This fixes a segfault caused by pandoc-style urls missing the closing `)`. The crash was found by the afl fuzzer.

For example
```markdown
%title: mdp - Sample Presentation
%author: visit1985
%date: 2014-09-22

-> mdp <-
=========
-> ## More information about markdown <-

can be found in the [markdown documentation](http://daringfireball.net/projects/markdown/
```
crashes with a segfault in `viewer.c:740` (see https://github.com/visit1985/mdp/blob/01a21345277528bb331653603e0d3771e5ed5870/src/viewer.c#L740)
