### PR TITLE
options to turn off display of slide # / # in footer

### DIFF
--- a/include/viewer.h
+++ b/include/viewer.h
@@ -55,7 +55,7 @@
 #define FADE_DELAY 15000 // micro seconds
 #define GOTO_SLIDE_DELAY 5    // tenths of seconds
 
-int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload);
+int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload, int slidenum);
 void add_line(WINDOW *window, int y, int x, line_t *line, int max_cols, int colors);
 void inline_display(WINDOW *window, const wchar_t *c, const int colors);
 void fade_out(WINDOW *window, int trans, int colors, int invert);

--- a/src/main.c
+++ b/src/main.c
@@ -29,12 +29,14 @@
 void usage() {
     fprintf(stderr, "%s", "Usage: mdp [OPTION]... [FILE]\n");
     fprintf(stderr, "%s", "A command-line based markdown presentation tool.\n\n");
-    fprintf(stderr, "%s", "  -d, --debug     enable debug messages on STDERR\n");
-    fprintf(stderr, "%s", "                  add it multiple times to increases debug level\n");
-    fprintf(stderr, "%s", "  -f, --nofade    disable color fading in 256 color mode\n");
-    fprintf(stderr, "%s", "  -h, --help      display this help and exit\n");
-    fprintf(stderr, "%s", "  -i, --invert    swap black and white color\n");
-    fprintf(stderr, "%s", "  -t, --notrans   disable transparency in transparent terminal\n");
+    fprintf(stderr, "%s", "  -d, --debug       enable debug messages on STDERR\n");
+    fprintf(stderr, "%s", "                    add it multiple times to increases debug level\n");
+    fprintf(stderr, "%s", "  -f, --nofade      disable color fading in 256 color mode\n");
+    fprintf(stderr, "%s", "  -h, --help        display this help and exit\n");
+    fprintf(stderr, "%s", "  -i, --invert      swap black and white color\n");
+    fprintf(stderr, "%s", "  -t, --notrans     disable transparency in transparent terminal\n");
+    fprintf(stderr, "%s", "  -s, --noslidenum  do not show slide number at the bottom\n");
+    fprintf(stderr, "%s", "  -x, --noslidemax  show slide number, but not total number of slides\n");
     fprintf(stderr, "%s", "\nWith no FILE, or when FILE is -, read standard input.\n\n");
     exit(EXIT_FAILURE);
 }
@@ -55,6 +57,7 @@ int main(int argc, char *argv[]) {
     int invert = 0;    // invert color (black on white)
     int reload = 0;    // reload page N (0 means no reload)
     int noreload = 1;  // reload disabled until we know input is a file
+    int slidenum = 2;  // 0:don't show; 1:show #; 2:show #/#
 
     // define command-line options
     struct option longopts[] = {
@@ -64,12 +67,14 @@ int main(int argc, char *argv[]) {
         { "invert",  no_argument, 0, 'i' },
         { "notrans", no_argument, 0, 't' },
         { "version", no_argument, 0, 'v' },
+        { "noslidenum", no_argument, 0, 's' },
+        { "noslidemax", no_argument, 0, 'x' },
         { 0, 0, 0, 0 }
     };
 
     // parse command-line options
     int opt, debug = 0;
-    while ((opt = getopt_long(argc, argv, ":dfhitv", longopts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, ":dfhitvsx", longopts, NULL)) != -1) {
         switch(opt) {
             case 'd': debug += 1; break;
             case 'f': nofade = 1; break;
@@ -77,6 +82,8 @@ int main(int argc, char *argv[]) {
             case 'i': invert = 1; break;
             case 't': notrans = 1; break;
             case 'v': version(); break;
+            case 's': slidenum = 0; break;
+            case 'x': slidenum = 1; break;
             case ':': fprintf(stderr, "%s: '%c' requires an argument\n", argv[0], optopt); usage(); break;
             case '?':
             default : fprintf(stderr, "%s: option '%c' is invalid\n", argv[0], optopt); usage(); break;
@@ -147,7 +154,7 @@ int main(int argc, char *argv[]) {
             markdown_debug(deck, debug);
         }
 
-        reload = ncurses_display(deck, notrans, nofade, invert, reload, noreload);
+        reload = ncurses_display(deck, notrans, nofade, invert, reload, noreload, slidenum);
 
         free_deck(deck);
 

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -60,7 +60,7 @@ static short red_ramp_invert[24]   = { 15, 231, 231, 224, 224, 225,
                                       206, 207, 201, 200, 199, 199,
                                       198, 198, 197, 197, 196, 196};
 
-int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload) {
+int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload, int slidenum) {
 
     int c = 0;          // char
     int i = 0;          // iterate
@@ -79,7 +79,7 @@ int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reloa
     int bar_top = (deck->headers > 0) ? 1 : 0;
     // header line 2 is displayed at the bottom
     // anyway we display the slide number at the bottom
-    int bar_bottom = 1;
+    int bar_bottom = (slidenum || deck->headers > 1)? 1 : 0;
 
     slide_t *slide = deck->slide;
     line_t *line;
@@ -283,9 +283,18 @@ int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reloa
         }
 
         // add slide number to right footer
-        mvwprintw(stdscr,
-                  LINES - 1, COLS - int_length(deck->slides) - int_length(sc) - 6,
-                  "%d / %d", sc, deck->slides);
+        switch(slidenum) {
+            case 1: // show slide number only
+                mvwprintw(stdscr,
+                          LINES - 1, COLS - int_length(sc) - 6,
+                          "%d", sc);
+                break;
+            case 2: // show current slide & number of slides
+                mvwprintw(stdscr,
+                          LINES - 1, COLS - int_length(deck->slides) - int_length(sc) - 6,
+                          "%d / %d", sc, deck->slides);
+                break;
+        }
 
         // make header + fooder visible
         wrefresh(content);


### PR DESCRIPTION
Fairly self-explanatory: I wanted to be able to turn off the `# / #` display in the footer. Here are two new options for customizing that:

    -s, --noslidenum  do not show slide number at the bottom
    -x, --noslidemax  show slide number, but not total number of slides

Suggestions welcome. Thanks!