### PR TITLE
Fix setting of locale

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -90,8 +90,9 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    // set locale to read and display UTF-8 correctly in ncurses
-    setlocale(LC_CTYPE, "en_US.UTF8");
+    // set locale to that of the environment, so that ncurses properly renders
+    // UTF-8 characters if the system supports it
+    setlocale(LC_CTYPE, "");
 
     // open file or set input to STDIN
     char *file = NULL;


### PR DESCRIPTION
OpenBSD, for example, doesn't have a locale named `UTF8`, as illustrated here:

```
/usr/share/locale $ ls
ARMSCII-8   CP866       ISO8859-13  ISO8859-2   ISO8859-5   ISO8859-9   KOI8-U
CP1251      ISO8859-1   ISO8859-15  ISO8859-4   ISO8859-7   KOI8-R      UTF-8
```

This causes UTF-8 characters to not be displayed, despite the LC_CTYPE
environment variable being set to `en_US.UTF-8` (which corresponds to an
actual locale on the system).

To avoid this issue, instead of telling getlocale(3) to use a fixed
locale, tell it to use the system's locale. From `man 3 setlocale`:

```
Only three locales are defined by default, the empty string "" which
denotes the native environment, and the "C" and "POSIX" locales, which
denote the C language environment.
```

closes #89