### PR TITLE
Added support for pandoc's fenced code blocks

### DIFF
--- a/include/markdown.h
+++ b/include/markdown.h
@@ -47,6 +47,7 @@ enum line_bitmask {
     IS_H2_ATX,
     IS_QUOTE,
     IS_CODE,
+    IS_TILDE_CODE,
     IS_HR,
     IS_UNORDERED_LIST_1,
     IS_UNORDERED_LIST_2,

--- a/include/parser.h
+++ b/include/parser.h
@@ -57,5 +57,6 @@ int next_nonblank(cstring_t *text, int i);
 int prev_blank(cstring_t *text, int i);
 int next_blank(cstring_t *text, int i);
 int next_word(cstring_t *text, int i);
+int next_nontilde(cstring_t *text, int i);
 
 #endif // !defined( PARSER_H )

--- a/sample.md
+++ b/sample.md
@@ -102,6 +102,32 @@ becomes
 
 -> # Supported markdown formatting <-
 
+You can also use [pandoc](http://pandoc.org/demo/example9/pandocs-markdown.html)'s fenced code block extension.
+Use at least three ~ chars to open and at least as many or 
+more ~ for closing.
+
+~~~~~
+~~~
+int main(int argc, char \*argv[]) {
+    printf("%s\\n", "Hello world!");
+}
+~~~
+~~~~~~~
+
+becomes
+
+~~~
+int main(int argc, char \*argv[]) {
+    printf("%s\\n", "Hello world!");
+}
+~~~
+
+Pandoc attributes (like ".numberlines" etc.) will be ignored
+
+-------------------------------------------------
+
+-> # Supported markdown formatting <-
+
 Quotes are auto-detected by preceding *>*.
 
 Multiple *>* are interpreted as nested quotes.

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -577,8 +577,10 @@ void add_line(WINDOW *window, int y, int x, line_t *line, int max_cols, int colo
     // IS_CODE
     if(CHECK_BIT(line->bits, IS_CODE)) {
 
-        // set static offset for code
-        offset = CODE_INDENT;
+	if (!CHECK_BIT(line->bits, IS_TILDE_CODE)) {
+		// set static offset for code
+		offset = CODE_INDENT;
+	}
 
         // reverse color for code blocks
         if(colors)


### PR DESCRIPTION
Code blocks can be started using three or more ~ characters and stopped
by the same or higher number of ~s. Additionally, pandoc attributes can
be specified. They are ignored in mdp, but may be used to get much nicer
output when converting the md file to html or pdf using pandoc.

For Example:
~~~~ {.bash .linenumbers}
ls $HOME # this is a comment
~~~~

See http://pandoc.org/demo/example9/pandocs-markdown.html