### PR TITLE
making PREFIX overridable, but still /usr/local by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SOURCES = $(wildcard src/*.c)
 OBJECTS = $(SOURCES:.c=.o)
 TARGET  = mdp
 DESTDIR =
-PREFIX  = /usr/local
+PREFIX  ?= /usr/local
 
 CURSES  = ncursesw
 LDFLAGS ?= -s


### PR DESCRIPTION
It's better not to have PREFIX hardcoded. Now, with '?=' it is still /usr/local by default, but can be overridden easily. That helps to create Debian package, which I intent to do.