### PR TITLE
Added instructions for the Raspberry Pi to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 mdp needs the ncursesw headers to compile.
 So make sure you have them installed:
+
 - on Cygwin you need `libncursesw10` and `libncurses-devel`
+- on Raspbian (Raspberry Pi) you need `libncurses5-dev` and `libncursesw5-dev`
 
 Now download and install mdp:
 


### PR DESCRIPTION
I could build mdp in a Raspberry Pi using the latest Raspbian. I just had to install two libraries for that, and I've added that information in the README.