### PR TITLE
Fix nested quote example in sample.md

### DIFF
--- a/sample.md
+++ b/sample.md
@@ -133,13 +133,13 @@ Multiple *>* are interpreted as nested quotes.
 
 \> quote
 \>> nested quote 1
-\> > nested quote 2
+\>>> nested quote 2
 
 becomes
 
 > quote
 >> nested quote 1
-> > nested quote 2
+>>> nested quote 2
 
 -------------------------------------------------
 


### PR DESCRIPTION
Fixes the nested quote example on page 8 of `sample.md`.

Before:
![mdp-sample-old](https://cloud.githubusercontent.com/assets/568543/19194306/257f7078-8c62-11e6-9d94-153a8dc520ce.png)

After:
![mdp-sample](https://cloud.githubusercontent.com/assets/568543/19194280/0bcd172a-8c62-11e6-9fe9-2d42b651cc4d.png)
