### PR TITLE
Support Github style code formatting

### DIFF
--- a/include/markdown.h
+++ b/include/markdown.h
@@ -48,6 +48,7 @@ enum line_bitmask {
     IS_QUOTE,
     IS_CODE,
     IS_TILDE_CODE,
+    IS_GFM_CODE,
     IS_HR,
     IS_UNORDERED_LIST_1,
     IS_UNORDERED_LIST_2,

--- a/include/parser.h
+++ b/include/parser.h
@@ -59,5 +59,6 @@ int prev_blank(cstring_t *text, int i);
 int next_blank(cstring_t *text, int i);
 int next_word(cstring_t *text, int i);
 int next_nontilde(cstring_t *text, int i);
+int next_nonbacktick(cstring_t *text, int i);
 
 #endif // !defined( PARSER_H )

--- a/sample.md
+++ b/sample.md
@@ -115,13 +115,37 @@ at least as many or more ~ for closing.
 becomes
 
 ~~~ {.numberLines}
-int main(int argc, char \*argv[]) {
-    printf("%s\\n", "Hello world!");
+int main(int argc, char *argv[]) {
+    printf("%s\n", "Hello world!");
 }
 ~~~~~~~~~~~~~~~~~~
 
 Pandoc attributes (like ".numberlines" etc.)
 will be ignored
+
+-------------------------------------------------
+
+-> # Supported markdown formatting <-
+
+You can also use [github](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) flavored markdown's
+code block. Use at least three backticks to open
+and at least as many or more backticks for closing.
+
+\```
+\int main(int argc, char \*argv[]) {
+\    printf("%s\\n", "Hello world!");
+\}
+\```
+
+becomes
+
+```
+int main(int argc, char *argv[]) {
+    printf("%s\n", "Hello world!");
+}
+```
+
+Language hint will be ignored
 
 -------------------------------------------------
 

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -656,7 +656,8 @@ void add_line(WINDOW *window, int y, int x, line_t *line, int max_cols, int colo
     // IS_CODE
     if(CHECK_BIT(line->bits, IS_CODE)) {
 
-        if (!CHECK_BIT(line->bits, IS_TILDE_CODE)) {
+        if (!CHECK_BIT(line->bits, IS_TILDE_CODE) &&
+            !CHECK_BIT(line->bits, IS_GFM_CODE)) {
             // set static offset for code
             offset = CODE_INDENT;
         }


### PR DESCRIPTION
Github uses triple (or more) backticks for block code formatting.
As it's widely used now, mdp should support that too.

Closes #116.