### PR TITLE
Fix build warning when chars are unsigned

### DIFF
--- a/src/viewer.c
+++ b/src/viewer.c
@@ -982,7 +982,7 @@ int int_length (int val) {
 
 int get_slide_number(char init) {
     int retval = init - '0';
-    char c;
+    int c;
     // block for tenths of a second when using getch, ERR if no input
     halfdelay(GOTO_SLIDE_DELAY);
     while((c = getch()) != ERR) {


### PR DESCRIPTION
Fix the following warning when chars are unsigned (as they are on arm):

```
viewer.c:988:25: warning: comparison of constant -1 with expression of type 'char' is always true
      [-Wtautological-constant-out-of-range-compare]
    while((c = getch()) != ERR) {
```