### PR TITLE
Pandoc fenced code link in sample

### DIFF
--- a/sample.md
+++ b/sample.md
@@ -102,7 +102,7 @@ becomes
 
 -> # Supported markdown formatting <-
 
-You can also use [pandoc](http://pandoc.org/demo/example9/pandocs-markdown.html)'s fenced code block
+You can also use [pandoc](https://pandoc.org/MANUAL.html#fenced-code-blocks)'s fenced code block
 extension. Use at least three ~ chars to open and
 at least as many or more ~ for closing.
 


### PR DESCRIPTION
Fixed the link, because https://pandoc.org/demo/example9/pandocs-markdown.html is

![image](https://user-images.githubusercontent.com/13085980/57981579-6489fc80-7a39-11e9-8038-72ad80ebefb4.png)
