### PR TITLE
add command line options for top & left indent

### DIFF
--- a/include/viewer.h
+++ b/include/viewer.h
@@ -55,7 +55,7 @@
 #define FADE_DELAY 15000 // micro seconds
 #define GOTO_SLIDE_DELAY 5    // tenths of seconds
 
-int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload, int slidenum, int nocodebg);
+int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload, int slidenum, int nocodebg, int top_indent, int left_indent);
 void add_line(WINDOW *window, int y, int x, line_t *line, int max_cols, int colors, int nocodebg);
 void inline_display(WINDOW *window, const wchar_t *c, const int colors, int nocodebg);
 void fade_out(WINDOW *window, int trans, int colors, int invert);

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,8 @@ void usage() {
     fprintf(stderr, "%s", "  -v, --version     display the version number and license\n");
     fprintf(stderr, "%s", "  -x, --noslidemax  show slide number, but not total number of slides\n");
     fprintf(stderr, "%s", "  -c, --nocodebg    don't change the background color of code blocks\n");
+    fprintf(stderr, "%s", "  -T, --top_indent  slide indent from the top of the terminal\n");
+    fprintf(stderr, "%s", "  -L, --left_indent slide indent from the left side of the terminal\n");
     fprintf(stderr, "%s", "\nWith no FILE, or when FILE is -, read standard input.\n\n");
     exit(EXIT_FAILURE);
 }
@@ -55,14 +57,16 @@ void version() {
 }
 
 int main(int argc, char *argv[]) {
-    int notrans = 0;   // disable transparency
-    int nofade = 0;    // disable fading
-    int invert = 0;    // invert color (black on white)
-    int noexpand = 1;  // disable character entity expansion
-    int reload = 0;    // reload page N (0 means no reload)
-    int noreload = 1;  // reload disabled until we know input is a file
-    int slidenum = 2;  // 0:don't show; 1:show #; 2:show #/#
-    int nocodebg = 0;  // 0:show code bg as inverted; 1: don't invert code bg
+    int notrans = 0;       // disable transparency
+    int nofade = 0;        // disable fading
+    int invert = 0;        // invert color (black on white)
+    int noexpand = 1;      // disable character entity expansion
+    int reload = 0;        // reload page N (0 means no reload)
+    int noreload = 1;      // reload disabled until we know input is a file
+    int slidenum = 2;      // 0:don't show; 1:show #; 2:show #/#
+    int nocodebg = 0;      // 0:show code bg as inverted; 1: don't invert code bg
+    int top_indent = 0;	   // slide indent from the top of the terminal
+    int left_indent = 0;   // slide indent from the left side of the terminal
 
     // define command-line options
     struct option longopts[] = {
@@ -76,12 +80,14 @@ int main(int argc, char *argv[]) {
         { "noslidenum", no_argument, 0, 's' },
         { "noslidemax", no_argument, 0, 'x' },
         { "nocodebg",   no_argument, 0, 'c' },
+        { "top_indent", required_argument, NULL, 'T' },
+        { "left_indent",required_argument, NULL, 'L' },
         { 0, 0, 0, 0 }
     };
 
     // parse command-line options
     int opt, debug = 0;
-    while ((opt = getopt_long(argc, argv, ":defhitvsxc", longopts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, ":defhitvsxcT:L:", longopts, NULL)) != -1) {
         switch(opt) {
             case 'd': debug += 1;   break;
             case 'e': noexpand = 0; break;
@@ -93,6 +99,8 @@ int main(int argc, char *argv[]) {
             case 's': slidenum = 0; break;
             case 'x': slidenum = 1; break;
             case 'c': nocodebg = 1; break;
+            case 'T': top_indent = strtol(optarg, NULL, 10); break;
+            case 'L': left_indent = strtol(optarg, NULL, 10); break;
             case ':': fprintf(stderr, "%s: '%c' requires an argument\n", argv[0], optopt); usage(); break;
             case '?':
             default : fprintf(stderr, "%s: option '%c' is invalid\n", argv[0], optopt); usage(); break;
@@ -167,7 +175,7 @@ int main(int argc, char *argv[]) {
             markdown_debug(deck, debug);
         }
 
-        reload = ncurses_display(deck, notrans, nofade, invert, reload, noreload, slidenum, nocodebg);
+        reload = ncurses_display(deck, notrans, nofade, invert, reload, noreload, slidenum, nocodebg, top_indent, left_indent);
 
         free_deck(deck);
 

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -73,7 +73,7 @@ static const char *list_head1 = " +- ";
 static const char *list_head2 = " +- ";
 static const char *list_head3 = " +- ";
 
-int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload, int slidenum, int nocodebg) {
+int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reload, int noreload, int slidenum, int nocodebg, int top_indent, int left_indent) {
 
     int c = 0;                // char
     int i = 0;                // iterate
@@ -338,8 +338,14 @@ int ncurses_display(deck_t *deck, int notrans, int nofade, int invert, int reloa
 
         // print lines
         while(line) {
-            add_line(content, l + ((LINES - slide->lines_consumed - bar_top - bar_bottom) / 2),
-                     (COLS - max_cols) / 2, line, max_cols, colors, nocodebg);
+	    if(l == 0) {		// display slide title horizontally centered
+		add_line(content, l + ((top_indent + bar_top - bar_bottom)),
+			 (COLS - max_cols) / 2, line, max_cols, colors, nocodebg);
+	    }
+	    else {
+		add_line(content, l + ((top_indent + bar_top - bar_bottom)),
+			 left_indent, line, max_cols, colors, nocodebg);
+	    }
 
             // raise stop counter if we pass a line having a stop bit
             if(CHECK_BIT(line->bits, IS_STOP))


### PR DESCRIPTION
Added options enable the user to define top and left indent of the presentation making the result more customizable. Proper implementation of slide title centering should be done. Added code assumes that the first line of any slide is the title regardless of content. Added code also somehow breaks markdown code blocks, that should also be fixed.

I'm aware that the solution is pretty hacky, but i've just wanted to add this without spending too much time figuring out how the whole program works.