### PR TITLE
Remove binary and manpage on `$ make uninstall`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ install:
 	install -m 644 mdp.1 $(DESTDIR)$(PREFIX)/share/man/man1/$(TARGET).1
 
 uninstall:
-	$(RM) $(DESTDIR)$(PREFIX)/$(TARGET)
+	$(RM) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	$(RM) $(DESTDIR)$(PREFIX)/share/man/man1/$(TARGET).1
 
 .PHONY: all clean install src uninstall


### PR DESCRIPTION
First of all, great program! Thank you for creating it.

First, I installed it from source using `make; make install`. But then I found out that mdp is also available on Homebrew. So I wanted to uninstall mdp in favor of the homebrew version. When I did this using `make uninstall`, I noticed it ran the command `rm -f /usr/local/mdp`, which is not the location the mdp binary is in. It also doesn't remove the corresponding man page. So this PR adds the ability to remove those two files that `make install` installs.