### PR TITLE
Add missing options to man page

### DIFF
--- a/mdp.1
+++ b/mdp.1
@@ -33,6 +33,9 @@ or if the file name is
 the presentation is read from standard input.
 .SS "Output Control"
 .TP
+.BR \-c ", " \-\^\-nocodebg
+Don't change the background color of code blocks.
+.TP
 .BR \-e ", " \-\^\-expand
 Enable character entity expansion (e.g. '&gt;' becomes '>').
 .TP
@@ -42,8 +45,14 @@ Disable color fading in 256 color mode.
 .BR \-i ", " \-\^\-invert
 Swap black and white color.
 .TP
+.BR \-s ", " \-\^\-noslidenum
+Do not show slide number at the bottom.
+.TP
 .BR \-t ", " \-\^\-notrans
 Disable transparency in transparent terminal.
+.TP
+.BR \-x ", " \-\^\-noslidemax
+Show slide number, but not total number of slides.
 .
 .SS "Miscellaneous Options"
 .TP


### PR DESCRIPTION
Info on `--nocodebg`, `--noslidenum`, and `--noslidemax` were missing in the man page.