### PR TITLE
Update package link for Arch Linux in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Now download and install mdp:
     $ make install
     $ mdp sample.md
 
-- On Arch Linux, you can use the existing [package](https://www.archlinux.org/packages/community/x86_64/mdp/).
+- On Arch Linux, you can use the existing [package](https://www.archlinux.org/packages/extra/x86_64/mdp/).
 - on Cygwin you can use the existing [package](https://cygwin.com/cgi-bin2/package-grep.cgi?grep=mdp.exe) from the setup program.
 - On Debian, you can use the existing [DEB package](https://tracker.debian.org/pkg/mdp-src), or run `apt-get install mdp`.
 - On FreeBSD, you can use the port [misc/mdp](http://www.freshports.org/misc/mdp).


### PR DESCRIPTION
Hi,

This PR updates the link to the Arch Linux package that is present in the README.md.

The current link leads to a 404.

The new link leads to the packages' page.

Thanks,