### PR TITLE
Fix int to char overflow for arrow keys

### DIFF
--- a/include/viewer.h
+++ b/include/viewer.h
@@ -60,6 +60,6 @@ void fade_in(WINDOW *window, int trans, int colors, int invert);
 int int_length (int val);
 int get_slide_number(char init);
 void setup_list_strings(void);
-bool evaluate_binding(const int bindings[], char c);
+bool evaluate_binding(const int bindings[], int c);
 
 #endif // !defined( VIEWER_H )

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -917,7 +917,7 @@ int get_slide_number(char init) {
     return retval;
 }
 
-bool evaluate_binding(const int bindings[], char c) {
+bool evaluate_binding(const int bindings[], int c) {
     int binding;
     int ind = 0; 
     while((binding = bindings[ind]) != 0) {


### PR DESCRIPTION
It would overflow if I pressed an arrow key.

For example, the right arrow key has a key code of 261. When it is cast to a char (1 byte), it overflows to the number 5.  As a result, the key is not recognized.